### PR TITLE
Feat: 다시하기 버튼과 url버튼 기능 구현

### DIFF
--- a/front-end/src/pages/result-page/ResultPage.js
+++ b/front-end/src/pages/result-page/ResultPage.js
@@ -8,6 +8,19 @@ const ResultsPage = () => {
   const navigate = useNavigate();
   const [formData, setFormData] = useState({});
   const [isLoading, setIsLoading] = useState(false);
+  const copyToClipboard = async () => {
+    try {
+      const shareUrl = `${window.location.origin}/resultPage?resultId=${formData.uuid}`;
+      await navigator.clipboard.writeText(shareUrl);
+      alert("URL이 클립보드에 복사되었습니다.");
+    } catch (err) {
+      console.error("클립보드 복사 실패:", err);
+    }
+  };
+
+  <div className="Button" onClick={copyToClipboard}>
+    URL 복사하기
+  </div>;
 
   useEffect(() => {
     const fetchData = async () => {
@@ -81,8 +94,10 @@ const ResultsPage = () => {
             <span className="Content">{formData.result_description}</span>
           </div>
           <div className="ButtonsContainer">
-            <div className="Button" onClick={() => navigate('/')}>다시하기</div>
-            <div className="Button">URL 복사하기</div>
+            <div className="Button" onClick={() => navigate("/")}>
+              다시하기
+            </div>
+            <div className="Button" onClick={copyToClipboard}>URL 복사하기</div>
             <div className="Button">카카오톡으로 공유</div>
           </div>
         </div>


### PR DESCRIPTION
기존에 UI만 구현해놨던 버튼들 기능 구현했습니다.
기능을 구현한 버튼 설명은 아래와 같습니다.

### 다시하기 버튼
버튼 클릭시 '/' 로 이동

### URL 복사하기 버튼
버튼 클릭시 uuid가 포함된 결과페이지 url 클립보드에 저장
성공시 : URL이 클립보드에 복사되었습니다. alert 페이지 작동
실패시 : 클립보드 복사 실패 콘솔로그에서 확인

